### PR TITLE
Update Quickfix package to work for ARM 

### DIFF
--- a/quickfix-python/setup.py
+++ b/quickfix-python/setup.py
@@ -68,7 +68,7 @@ ext = Extension(
 
 setup(
     name='quickfix-albert',
-    version='1.15.13',
+    version='1.15.14',
     py_modules=['quickfix', 'quickfixt11', 'quickfix40', 'quickfix41',
               'quickfix42', 'quickfix43', 'quickfix44', 'quickfix50',
               'quickfix50sp1', 'quickfix50sp2'],

--- a/quickfix-python/setup.py
+++ b/quickfix-python/setup.py
@@ -68,7 +68,7 @@ ext = Extension(
 
 setup(
     name='quickfix-albert',
-    version='1.15.14',
+    version='1.15.16',
     py_modules=['quickfix', 'quickfixt11', 'quickfix40', 'quickfix41',
               'quickfix42', 'quickfix43', 'quickfix44', 'quickfix50',
               'quickfix50sp1', 'quickfix50sp2'],

--- a/src/C++/AtomicCount.h
+++ b/src/C++/AtomicCount.h
@@ -155,7 +155,7 @@ private:
       // int r = *pw;
       // *pw += dv;
       // return r;
-
+    #if ( defined( __i386__ ) || defined( __x86_64__ ) )
       int r;
 
       __asm__ __volatile__
@@ -168,6 +168,14 @@ private:
         );
 
       return r;
+    #elif ( defined( __arm__ ) || defined( __aarch64__ ) )
+      // supported on gcc and clang
+        return __atomic_fetch_add(pw, dv, __ATOMIC_SEQ_CST);
+    #else // other architectures
+        // supported on gcc and clang
+        return __atomic_fetch_add(pw, dv, __ATOMIC_SEQ_CST);
+    #endif
+
     }
   };
 


### PR DESCRIPTION
## Purpose

- https://meetalbert.slack.com/archives/C02Q35TNT0C/p1653435392732459?thread_ts=1653416315.889539&cid=C02Q35TNT0C

Add the changes in the slack thread to the quickfix package. Youll need to spin teal back up and test trading to make sure this doesnt break anything when we update the versions in investing and investing tr.

## Asana task

- [Update Quickfix package to work for ARM ](https://app.asana.com/0/1202326121555266/1202333050991491/f)

## Approach

- This PR was based on: https://github.com/quickfix/quickfix/pull/379/files

## Testing

- I could test the new library on teal:
* **Trades**: https://albert-dev-teal-investing.herokuapp.com/admin/investing/securitytrade/?investment_transaction_id=933797
* **Fix Messages**: https://albert-dev-teal-investing.herokuapp.com/admin/investing/fixmessage/?reported_timestamp__contains=2022-05-27
* **Papetrail Logs**: https://my.papertrailapp.com/systems/albert-dev-teal-investing-tr/events?q=+Reporting+FIX+messages

 